### PR TITLE
exclude Map and Set from polyfill to try to fix Symbol error

### DIFF
--- a/client/components/core/top.js
+++ b/client/components/core/top.js
@@ -144,7 +144,7 @@ var polyfill_features = [
 
 var polfill_url = 'https://cdn.polyfill.io/v2/polyfill.min.js?callback=clear_queue&features='
                     + polyfill_features.join(',')
-                    + '&excludes=Symbol,Symbol.iterator,Symbol.species';
+                    + '&excludes=Symbol,Symbol.iterator,Symbol.species,Map,Set';
 
 exec(polfill_url, true, false, null, {crossorigin: 'anonymous'})
 


### PR DESCRIPTION
Try excluding Map and Set from polyfill to try to make IE11 work

![screen shot 2017-03-20 at 9 39 42 pm](https://cloud.githubusercontent.com/assets/1794257/24129216/6f1181d2-0db7-11e7-9c1e-0f6ba8beae97.png)

References: https://github.com/Financial-Times/polyfill-service/issues/715